### PR TITLE
Add support for characterset in mb_strtoupper-call

### DIFF
--- a/lib/Html2Text/Html2Text.php
+++ b/lib/Html2Text/Html2Text.php
@@ -681,6 +681,7 @@ class Html2Text
 
     /**
      * Strtoupper multibyte wrapper function with HTML entities handling.
+     * Forces mb_strtoupper-call to UTF-8.
      *
      * @param string $str Text to convert
      * @return string Converted text
@@ -690,7 +691,7 @@ class Html2Text
         $str = html_entity_decode($str, ENT_COMPAT);
 
         if (function_exists('mb_strtoupper'))
-            $str = mb_strtoupper($str);
+            $str = mb_strtoupper($str, 'UTF-8');
         else
             $str = strtoupper($str);
 

--- a/test/StrToUpperTest.php
+++ b/test/StrToUpperTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once __DIR__.'/../lib/Html2Text/Html2Text.php';
+
+class StrToUpperTest extends PHPUnit_Framework_TestCase
+{
+    public $input =<<<EOT
+<h1>Will be UTF-8 (äöüèéилčλ) uppercased</h1>
+<p>Will remain lowercased</p>
+EOT;
+
+    public function testStrToUpper()
+    {
+        $expected_output =<<<EOT
+WILL BE UTF-8 (ÄÖÜÈÉИЛČΛ) UPPERCASED
+
+Will remain lowercased
+EOT;
+
+        $html2text = new \Html2Text\Html2Text($this->input);
+        $output = $html2text->get_text();
+
+        $this->assertEquals($expected_output, $output);
+    }
+}


### PR DESCRIPTION
As the internal encoding is not always used in mb_strtoupper I added an option to set the characterset in _options and use it in the _strtoupper-call.
