### PR TITLE
Minor changes to stop code warnings appearing in Zend Studio 10.5.

### DIFF
--- a/lib/Html2Text/Html2Text.php
+++ b/lib/Html2Text/Html2Text.php
@@ -561,9 +561,9 @@ class Html2Text
      */
     private function _convert_blockquotes(&$text)
     {
-        $start = 0;
-        $taglen = 0;
         if (preg_match_all('/<\/*blockquote[^>]*>/i', $text, $matches, PREG_OFFSET_CAPTURE)) {
+            $start = 0;
+            $taglen = 0;
             $level = 0;
             $diff = 0;
             foreach ($matches[0] as $m) {


### PR DESCRIPTION
# Changes Made:
- Changed double quotes around preg_match pattern to single quote in _preg_callback() function to stop "Bad escape sequence: \w" warning.
- Added "$start = 0" and "$taglen = 0" to beginning of _convert_blockquotes() function to stop "Undefined variable" warnings.
## Notes:

None of these changes cause the Htlm2Text class work in a different way to the previous version. Very much "cosmetic"!
