### PR TITLE
Added method for adding custom search and replace rules

### DIFF
--- a/lib/Html2Text/Html2Text.php
+++ b/lib/Html2Text/Html2Text.php
@@ -362,6 +362,24 @@ class Html2Text
     }
 
     /**
+     * Add custom pattern for search and replacement for this
+     * @param array $rules = [
+     *      "pattern_1" => "replacement_for_pattern_1",
+     *      "pattern_2" => "replacement_for_pattern_2",
+     * ]
+     */
+    public function add_ent_search_and_replace(array $rules = array())
+    {
+        $this->ent_search = array_merge(
+            $this->ent_search, array_keys($rules)
+        );
+
+        $this->ent_replace = array_merge(
+            $this->ent_replace, array_values($rules)
+        );
+    }
+
+    /**
      * Workhorse function that does actual conversion (calls _converter() method).
      */
     protected function _convert()

--- a/test/CustomSearchRuleTest.php
+++ b/test/CustomSearchRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once __DIR__.'/../lib/Html2Text/Html2Text.php';
+
+class CustomSearchRuleTest extends PHPUnit_Framework_TestCase
+{
+    public $input =<<<EOT
+This library name is &laquo;Html2Text&raquo;
+EOT;
+
+    public function testStrToUpper()
+    {
+        $expected_output =<<<EOT
+This library name is «Html2Text»
+EOT;
+
+        $html2text = new \Html2Text\Html2Text($this->input);
+        $html2text->add_ent_search_and_replace(array(
+            '/&laquo;/i' => '«',
+            '/&raquo;/i' => '»'
+        ));
+
+        $output = $html2text->get_text();
+
+        $this->assertEquals($expected_output, $output);
+    }
+}


### PR DESCRIPTION
It is often necessary to add their own rules to search and replace, e.g. replace `&raquo;` with `»`, but it is not possible without creating a wrapper.

This PR add method `add_ent_search_and_replace` for adding custom replacement rules.
This method accept one argument of type array ($rules), which must be looks like this:

``` php
array(
    '/&laquo;/i' => '«',
    '/&raquo;/i' => '»'
)
```

Usage example there is in CustomSearchRuleTest.
