### PR TITLE
- Adjustments for the support accented characters across the library.

### DIFF
--- a/lib/Html2Text/Html2Text.php
+++ b/lib/Html2Text/Html2Text.php
@@ -426,7 +426,7 @@ class Html2Text
         $text = preg_replace($this->ent_search, $this->ent_replace, $text);
 
         // Replace known html entities
-	// Facing encoding issue with accented characters, hence forcing to utf-8 in order to maintain the support Internalization.(mostly replicable in PHP 5.3)
+        // Facing encoding issue with accented characters, hence forcing to utf-8 in order to maintain the support Internalization.(mostly replicable in PHP 5.3)
         $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
 
         // Remove unknown/unhandled entities (this cannot be done in search-and-replace block)
@@ -666,7 +666,7 @@ class Html2Text
      */
     private function _strtoupper($str)
     {
-	// Facing encoding issue with accented characters, hence forcing to utf-8 in order to maintain the support Internalization.(mostly replicable in PHP 5.3)
+        // Facing encoding issue with accented characters, hence forcing to utf-8 in order to maintain the support Internalization.(mostly replicable in PHP 5.3)
         $str = html_entity_decode($str, ENT_COMPAT, 'UTF-8');
 
         if (function_exists('mb_strtoupper'))


### PR DESCRIPTION
When content have Spanish or accented characters like "áéíóñ" in content body, the text gets stripped off while converting html to text.

For more please refer the following link:
https://kayako.atlassian.net/browse/SWIFT-4021
