### PR TITLE
Moved our protocol regex up into a protected variable

### DIFF
--- a/lib/Html2Text/Html2Text.php
+++ b/lib/Html2Text/Html2Text.php
@@ -215,6 +215,13 @@ class Html2Text
     protected $pre_content = '';
 
     /**
+     * The regex that determines whether a link needs our base_url applied or not.
+     *
+     * @type string
+     */
+    protected $link_protocol_regex = '!^([a-z][a-z0-9.+-]+:)!i';
+
+    /**
      * Contains a list of HTML tags to allow in the resulting text.
      *
      * @type string
@@ -476,7 +483,7 @@ class Html2Text
             return $display;
         }
 
-        if (preg_match('!^([a-z][a-z0-9.+-]+:)!i', $link)) {
+        if (preg_match($this->link_protocol_regex, $link)) {
             $url = $link;
         } else {
             $url = $this->url;


### PR DESCRIPTION
@mtibben Appreciate your work on this library.  Not sure if you will want to pull this tweak in, but I'm finding it useful.

I'm using it so that I can override the regex used to determine whether to add a base url or not.  When we're generating plain text bodies for emails, we sometimes use a Mailgun variable symbol (`%`) to indicate an absolute url that gets swapped in with a Mailgun variable at a later point.

With your current system, I was ending up with the following type of link:

http://www.hostname.com/http://www.hostname.com/link-from-variable

where the first `www.hostname.com` was generated by Html2Text.

Having the ability to control the regex allows me to prevent that from happening.

At the moment, I'm overriding that protected variable in a subclass, but if you want to add this patch, I can send over a tweak to the pull request to add a setter for it as well.
