### PR TITLE
Let PHP do the work of decoding entities

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -118,19 +118,8 @@ class Html2Text
      * @see $entReplace
      */
     protected $entSearch = array(
-        '/&(nbsp|#160);/i',                              // Non-breaking space
-        '/&(quot|rdquo|ldquo|#8220|#8221|#147|#148);/i', // Double quotes
-        '/&(apos|rsquo|lsquo|#8216|#8217);/i',           // Single quotes
-        '/&gt;/i',                                       // Greater-than
-        '/&lt;/i',                                       // Less-than
-        '/&(copy|#169);/i',                              // Copyright
-        '/&(trade|#8482|#153);/i',                       // Trademark
-        '/&(reg|#174);/i',                               // Registered
-        '/&(mdash|#151|#8212);/i',                       // mdash
-        '/&(ndash|minus|#8211|#8722);/i',                // ndash
-        '/&(bull|#149|#8226);/i',                        // Bullet
-        '/&(pound|#163);/i',                             // Pound sign
-        '/&(euro|#8364);/i',                             // Euro sign
+        '/&#153;/i',                                     // TM symbol in win-1252
+        '/&#151;/i',                                     // m-dash in win-1252
         '/&(amp|#38);/i',                                // Ampersand: see converter()
         '/[ ]{2,}/',                                     // Runs of spaces, post-handling
     );
@@ -142,19 +131,8 @@ class Html2Text
      * @see $entSearch
      */
     protected $entReplace = array(
-        ' ',         // Non-breaking space
-        '"',         // Double quotes
-        "'",         // Single quotes
-        '>',
-        '<',
-        '(c)',
-        '(tm)',
-        '(R)',
-        '--',
-        '-',
-        '*',
-        '£',
-        'EUR',       // Euro sign. € ?
+        '™',         // TM symbol
+        '—',         // m-dash
         '|+|amp|+|', // Ampersand: see converter()
         ' ',         // Runs of spaces, post-handling
     );

--- a/test/BlockquoteTest.php
+++ b/test/BlockquoteTest.php
@@ -22,7 +22,7 @@ EOT;
         $expected =<<<'EOT'
 Before 
 
-> Foo bar baz HTML symbols &
+> Foo bar baz HTML symbols &
 
 After
 EOT;

--- a/test/HtmlCharsTest.php
+++ b/test/HtmlCharsTest.php
@@ -12,4 +12,47 @@ class HtmlCharsTest extends \PHPUnit_Framework_TestCase
         $html2text = new Html2Text($html);
         $this->assertEquals($expected, $html2text->getText());
     }
+
+    public function provideSymbols()
+    {
+        // A variety of symbols that either used to have special handling
+        // or still does.
+        return array(
+            // Non-breaking space, not a regular one.
+            array('&nbsp;', ' '),
+            array('&gt;', '>'),
+            array('&lt;', '<'),
+            array('&copy;', '©'),
+            array('&#169;', '©'),
+            array('&trade;', '™'),
+            // The TM symbol in Windows-1252, invalid in HTML...
+            array('&#153;', '™'),
+            // Correct TM symbol numeric code
+            array('&#8482;', '™'),
+            array('&reg;', '®'),
+            array('&#174;', '®'),
+            array('&mdash;', '—'),
+            // The m-dash in Windows-1252, invalid in HTML...
+            array('&#151;', '—'),
+            // Correct m-dash numeric code
+            array('&#8212;', '—'),
+            array('&bull;', '•'),
+            array('&pound;', '£'),
+            array('&#163;', '£'),
+            array('&euro;', '€'),
+            array('&amp;', '&'),
+        );
+    }
+
+    /**
+     * @dataProvider provideSymbols
+     */
+    public function testSymbol($entity, $symbol)
+    {
+        $html = "$entity signs should be UTF-8 symbols";
+        $expected = "$symbol signs should be UTF-8 symbols";
+
+        $html2text = new Html2Text($html);
+        $this->assertEquals($expected, $html2text->getText());
+    }
 }

--- a/test/PreTest.php
+++ b/test/PreTest.php
@@ -22,9 +22,9 @@ EOT;
         $expected =<<<'EOT'
 Before 
 
-Foo bar baz
+Foo bar baz
 
-HTML symbols &
+HTML symbols &
 
 After
 EOT;


### PR DESCRIPTION
Rather than maintaining lists of entities to search for and replace, let
PHP do the work, and just maintain a list of exceptions where necessary.

Exceptions are for where the code previously supported windows-cp1252
entities and for special support for ampersands.

This also means that the proper character will be used, for example
rather than &copy; being decoded into (c) it will be decoded into ©.
