### PR TITLE
Supports image alt text

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -66,6 +66,7 @@ class Html2Text
         '/(<table[^>]*>|<\/table>)/i',                    // <table> and </table>
         '/(<tr[^>]*>|<\/tr>)/i',                          // <tr> and </tr>
         '/<td[^>]*>(.*?)<\/td>/i',                        // <td> and </td>
+        '/<img(?:.*?)alt=("|\')(.*?)("|\')(?:.*?)>/i',    // img alt text
         '/<span class="_html2text_ignore">.+?<\/span>/i', // <span class="_html2text_ignore">...</span>
     );
 
@@ -97,6 +98,7 @@ class Html2Text
         "\n\n",                          // <table> and </table>
         "\n",                            // <tr> and </tr>
         "\t\t\\1\n",                     // <td> and </td>
+        "image: \\1\\2\\3",              // img alt text
         ""                               // <span class="_html2text_ignore">...</span>
     );
 
@@ -112,6 +114,7 @@ class Html2Text
         '/&#151;/i',                                     // m-dash in win-1252
         '/&(amp|#38);/i',                                // Ampersand: see converter()
         '/[ ]{2,}/',                                     // Runs of spaces, post-handling
+        '/&nbsp;/',                                      // Prevent strange characters
     );
 
     /**
@@ -125,6 +128,7 @@ class Html2Text
         '—',         // m-dash
         '|+|amp|+|', // Ampersand: see converter()
         ' ',         // Runs of spaces, post-handling
+        ' ',         // Prevent strange characters
     );
 
     /**

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Html2Text;
+
+class ImageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShowAltText()
+    {
+        $html = new Html2Text('<img id="head" class="header" src="imgs/logo.png" alt="This is our cool logo" />');
+
+        $this->assertEquals('image: "This is our cool logo"', $html->getText());
+    }
+}

--- a/test/SpaceTest.php
+++ b/test/SpaceTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Html2Text;
+
+class SpaceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSpaces()
+    {
+        $html = new Html2Text('This&nbsp;is&nbsp;a&nbsp;text&nbsp;with&nbsp;a&nbsp;lot&nbsp;of&nbsp;spaces.');
+
+        $this->assertEquals('This is a text with a lot of spaces.', $html->getText());
+    }
+}


### PR DESCRIPTION
* Replaces img tags with its alt text.
* On some occasions it replaced `&nbsp;` with `Ã `. Adding  `&nbsp;` to `entSearch` fixed the problem for me.