### PR TITLE
Increase visibility of toupper, and strtoupper

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -548,7 +548,7 @@ class Html2Text
      * @param  string $str Text to convert
      * @return string Converted text
      */
-    private function toupper($str)
+    protected function toupper($str)
     {
         // string can contain HTML tags
         $chunks = preg_split('/(<[^>]*>)/', $str, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
@@ -569,7 +569,7 @@ class Html2Text
      * @param  string $str Text to convert
      * @return string Converted text
      */
-    private function strtoupper($str)
+    protected function strtoupper($str)
     {
         $str = html_entity_decode($str, ENT_COMPAT, self::ENCODING);
 


### PR DESCRIPTION
Some uses of this library may wish to have their own implementations of
these functions which, for example, include different handling of encoding.

By modifying the visibility of these functions from private, to public, it
becomes possible for them to extend the Html2text\Html2text class and
override these functions with their own implementations.