### PR TITLE
Supply the image alt text when converting images

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -67,6 +67,7 @@ class Html2Text
         '/(<tr[^>]*>|<\/tr>)/i',                          // <tr> and </tr>
         '/<td[^>]*>(.*?)<\/td>/i',                        // <td> and </td>
         '/<span class="_html2text_ignore">.+?<\/span>/i', // <span class="_html2text_ignore">...</span>
+        '/<(img)[^>]*alt=\"([^>"]+)\"[^>]*>/i',           // <img> with alt tag
     );
 
     /**
@@ -97,7 +98,8 @@ class Html2Text
         "\n\n",                          // <table> and </table>
         "\n",                            // <tr> and </tr>
         "\t\t\\1\n",                     // <td> and </td>
-        ""                               // <span class="_html2text_ignore">...</span>
+        "",                              // <span class="_html2text_ignore">...</span>
+        '[\\2]',                         // <img> with alt tag
     );
 
     /**

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Html2Text;
+
+class ImageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImageDataProvider() {
+        return array(
+            'Without alt tag' => array(
+                'html' => '<img src="http://example.com/example.jpg">',
+                'expected'  => '',
+            ),
+            'Without alt tag, wrapped in text' => array(
+                'html' => 'xx<img src="http://example.com/example.jpg">xx',
+                'expected'  => 'xxxx',
+            ),
+            'With alt tag' => array(
+                'html' => '<img src="http://example.com/example.jpg" alt="An example image">',
+                'expected'  => '[An example image]',
+            ),
+            'With alt, and title tags' => array(
+                'html' => '<img src="http://example.com/example.jpg" alt="An example image" title="Should be ignored">',
+                'expected'  => '[An example image]',
+            ),
+            'With alt tag, wrapped in text' => array(
+                'html' => 'xx<img src="http://example.com/example.jpg" alt="An example image">xx',
+                'expected'  => 'xx[An example image]xx',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider testImageDataProvider
+     */
+    public function testImages($html, $expected)
+    {
+        $html2text = new Html2Text($html);
+        $output = $html2text->getText();
+
+        $this->assertEquals($expected, $output);
+    }
+}


### PR DESCRIPTION
As per WCAG 2.0 guidelines (http://www.w3.org/TR/WCAG20-TECHS/H37.html), images which convey words should be provided with alt text which includes those words.

In order to provide an accessible version of this HTML content, and where an alt tag has been provided, the alt text should be made available.

Where text refers to an image inline (for example, an emoticon), complete removal of that image can confuse the meaning of the text.  This also relates to images which convey meaning in some other fashion - for example, an image displaying a graph. Although a disabled user will not necessarily be able to view that graph, its presence within the document is important information and should still be conveyed.
Where an image is present, and does not contain an alt-text, it should have its role attribute set to 'presentation' instead.

I realise that this duplicates #39, however that version includes the english-language string "image" in
the outputted content which would break for translations.

As a side-note, we have been using this modification to Html2Text in Moodle since August 2010.