### PR TITLE
Stop running stripslashes on input text

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -320,7 +320,7 @@ class Html2Text
     {
         $this->linkList = array();
 
-        $text = trim(stripslashes($this->html));
+        $text = trim($this->html);
 
         $this->converter($text);
 

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -4,10 +4,26 @@ namespace Html2Text;
 
 class BasicTest extends \PHPUnit_Framework_TestCase
 {
-    public function testBasicUsageInReadme()
-    {
-        $html = new Html2Text('Hello, &quot;<b>world</b>&quot;');
+    public function basicDataProvider() {
+        return array(
+            'Usage in Readme' => array(
+                'html'      => 'Hello, &quot;<b>world</b>&quot;',
+                'expected'  => 'Hello, "WORLD"',
+            ),
+            'No stripslashes on HTML content' => array(
+                // HTML content does not escape slashes, therefore nor should we.
+                'html'      => 'Hello, \"<b>world</b>\"',
+                'expected'  => 'Hello, \"WORLD\"',
+            ),
+        );
+    }
 
-        $this->assertEquals('Hello, "WORLD"', $html->getText());
+    /**
+     * @dataProvider basicDataProvider
+     */
+    public function testBasic($html, $expected)
+    {
+        $html = new Html2Text($html);
+        $this->assertEquals($expected, $html->getText());
     }
 }


### PR DESCRIPTION
HTML content preserves slashes (\), and so should Html2Text when it
converts content.

Note: This is a potentially breaking change as it will mean that slashes
are no longer stripped out of content where developers were expecting
Html2Text to perform their sanitisation.