### PR TITLE
Increment diff counter in blockqute parsing (Fixes #37)

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -488,7 +488,7 @@ class Html2Text
                         $text = substr($text, 0, $start - $diff)
                             . $body . substr($text, $end + strlen($m[0]) - $diff);
 
-                        $diff = $len + $taglen + strlen($m[0]) - strlen($body);
+                        $diff += $len + $taglen + strlen($m[0]) - strlen($body);
                         unset($body);
                     }
                 } else {

--- a/test/BlockquoteTest.php
+++ b/test/BlockquoteTest.php
@@ -4,9 +4,11 @@ namespace Html2Text;
 
 class BlockquoteTest extends \PHPUnit_Framework_TestCase
 {
-    public function testBlockquote()
+    public function blockquoteDataProvider()
     {
-        $html =<<<'EOT'
+        return array(
+            'Basic blockquote' => array(
+                'html' => <<<EOT
 <p>Before</p>
 <blockquote>
 
@@ -17,16 +19,49 @@ HTML symbols &amp;
 
 </blockquote>
 <p>After</p>
-EOT;
-
-        $expected =<<<'EOT'
+EOT
+                ,
+                'expected' => <<<EOT
 Before 
 
 > Foo bar baz HTML symbols &
 
 After
-EOT;
+EOT
+                ,
+            ),
+            'Multiple blockquotes in text' => array(
+                'html' => <<<EOF
+<p>Highlights from today&rsquo;s <strong>Newlyhired Game</strong>:</p><blockquote><p><strong>Sean:</strong> What came first, Blake&rsquo;s first <em>Chief Architect position</em> or Blake&rsquo;s first <em>girlfriend</em>?</p> </blockquote> <blockquote> <p><strong>Sean:</strong> Devin, Bryan spent almost five years of his life slaving away for this vampire squid wrapped around the face of humanity&hellip;<br/><strong>Devin:</strong> Goldman Sachs?<br/><strong>Sean:</strong> Correct!</p> </blockquote> <blockquote> <p><strong>Sean:</strong> What was the name of the girl Zhu took to prom three months ago?<br/><strong>John:</strong> What?<br/><strong>Derek (from the audience):</strong> Destiny!<br/><strong>Zhu:</strong> Her name is Jolene. She&rsquo;s nice. I like her.</p></blockquote><p>I think the audience is winning.&nbsp; - Derek</p>
+EOF
+                ,
+                'expected' => <<<EOF
+Highlights from today’s NEWLYHIRED GAME:
 
+> SEAN: What came first, Blake’s first _Chief Architect position_ or
+> Blake’s first _girlfriend_?
+
+> SEAN: Devin, Bryan spent almost five years of his life slaving away
+> for this vampire squid wrapped around the face of humanity…
+> DEVIN: Goldman Sachs?
+> SEAN: Correct!
+
+> SEAN: What was the name of the girl Zhu took to prom three months
+> ago?
+> JOHN: What?
+> DEREK (FROM THE AUDIENCE): Destiny!
+> ZHU: Her name is Jolene. She’s nice. I like her.
+
+I think the audience is winning.  - Derek
+EOF
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider blockquoteDataProvider
+     */
+    public function testBlockquote($html, $expected) {
         $html2text = new Html2Text($html);
         $this->assertEquals($expected, $html2text->getText());
     }


### PR DESCRIPTION
The blockquote counter should be incremented when parsing quoted text,
rather than set to the length of the quote. If there are multiple
blockquotes in the text then the position counter must be tracked
additively and cannot be assumed to start from zero each time.

Thanks to @voku, who provided this patch. I've just grabbed his patch, and
removed his local customisations for UTF8 versions of strlen.