### PR TITLE
Show links as BBCode

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -210,6 +210,7 @@ class Html2Text
                                 // 'inline' (show links inline)
                                 // 'nextline' (show links on the next line)
                                 // 'table' (if a table of link URLs should be listed after the text.
+                                // 'bbcode' (show links as bbcode)
 
         'width' => 70,          //  Maximum width of the formatted text, in columns.
                                 //  Set this value to 0 (or less) to ignore word wrapping
@@ -409,6 +410,8 @@ class Html2Text
             return $display . ' [' . ($index + 1) . ']';
         } elseif ($linkMethod == 'nextline') {
             return $display . "\n[" . $url . ']';
+        } elseif ($linkMethod == 'bbcode') {
+            return sprintf('[url=%s]%s[/url]', $url, $display);
         } else { // link_method defaults to inline
             return $display . ' [' . $url . ']';
         }

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -135,4 +135,14 @@ EOT;
 
         $this->assertEquals($expected, $html2text->getText());
     }
+
+    public function testDoLinksBBCode()
+    {
+        $html = '<a href="http://example.com"><b>Link text</b></a>';
+        $expected = '[url=http://example.com]LINK TEXT[/url]';
+
+        $html2text = new Html2Text($html, array('do_links' => 'bbcode'));
+
+        $this->assertEquals($expected, $html2text->getText());
+    }
 }


### PR DESCRIPTION
It would be nice to have [BBCode](https://en.wikipedia.org/wiki/BBCode) support. I've used this solution on [a fork](https://github.com/zelazowy/html2text) for over a year.