### PR TITLE
Add a simple bootstrap file to decouple the test suite from Composer.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="test/bootstrap.php"
 >
     <testsuites>
         <testsuite name="Html2Text Test Suite">

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * Our test cases rely on PSR-4 autoloading, but no autoloader is
+ * shipped with the library. Composer will create one, but if the
+ * library is installed in some other manner, the test suite won't
+ * run. By using this file to bootstrap PHPUnit, we allow the test
+ * suite to run out-of-the-box for distributions and users who prefer
+ * not to use Composer.
+ */
+require('src/Html2Text.php');
+?>


### PR DESCRIPTION
The test case files all depend on PSR-4 autoloading, but no autoloader
exists when the library is installed through (for example) a
distribution package manager. Fortunately the bootstrap process is
simple and this can be fixed with a single "require" statement.

This commit adds a new file, test/bootstrap.php, which loads the
Html2Text library. We then use this new file to bootstrap PHPUnit. The
end result is that the test suite now works out-of-the-box without
Composer. Running,

  $ phpunit

should succeed from an unmodified tarball.