### PR TITLE
preg_split() compatibility with HHVM

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -565,7 +565,7 @@ class Html2Text
     protected function toupper($str)
     {
         // string can contain HTML tags
-        $chunks = preg_split('/(<[^>]*>)/', $str, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $chunks = preg_split('/(<[^>]*>)/', $str, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
 
         // convert toupper only the text between HTML tags
         foreach ($chunks as $i => $chunk) {


### PR DESCRIPTION
HHVM has a bug that it does not accept NULL as a third argument in preg_split() function and throws warning. Default value -1 does the same (no limit) and works also in HHVM.

HHVM issue: https://github.com/facebook/hhvm/issues/6815