### PR TITLE
Always use multibyte string functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4"
+    },
+    "suggest": {
+        "ext-mbstring": "For best performance",
+        "symfony/polyfill-mbstring": "If you can't install ext-mbstring"
     }
 }


### PR DESCRIPTION
Always use mb_* functions.

If users don't have the mb extension, suggest a fallback to https://github.com/symfony/polyfill-mbstring
