### PR TITLE
Fix multibyte text problem in blockquotes

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -472,11 +472,13 @@ class Html2Text
     protected function convertBlockquotes(&$text)
     {
         if (preg_match_all('/<\/*blockquote[^>]*>/i', $text, $matches, PREG_OFFSET_CAPTURE)) {
+            $originalText = $text;
             $start = 0;
             $taglen = 0;
             $level = 0;
             $diff = 0;
             foreach ($matches[0] as $m) {
+                $m[1] = mb_strlen(substr($originalText, 0, $m[1]));
                 if ($m[0][0] == '<' && $m[0][1] == '/') {
                     $level--;
                     if ($level < 0) {

--- a/test/BlockquoteTest.php
+++ b/test/BlockquoteTest.php
@@ -57,6 +57,21 @@ I think the audience is winning.  - Derek
 
 EOF
             ),
+            'Multibyte strings before blockquote' => array(
+                'html' => <<<EOF
+“Hello”
+
+<blockquote>goodbye</blockquote>
+
+EOF
+                ,
+                'expected' => <<<EOF
+“Hello” 
+
+> goodbye
+
+EOF
+            )
         );
     }
 


### PR DESCRIPTION
Since converting the string functions to their mb_ equivalents, `PREG_OFFSET_CAPTURE` can now be "incorrect", the mb_ functions give the position of characters in the string, wheras `PREG_OFFSET_CAPTURE` gives the _byte_ offset. This meant that for some strings, `mb_substr` in `convertBlockquotes` was truncating the strings in the wrong place.