### PR TITLE
Stronger regex for <i> tags

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -52,7 +52,7 @@ class Html2Text
         '/<head[^>]*>.*?<\/head>/i',                      // <head>
         '/<script[^>]*>.*?<\/script>/i',                  // <script>s -- which strip_tags supposedly has problems with
         '/<style[^>]*>.*?<\/style>/i',                    // <style>s -- which strip_tags supposedly has problems with
-        '/<i[^>]*>(.*?)<\/i>/i',                          // <i>
+        '/<i(?!mg)[^>]*>(.*?)<\/i>/i',                    // <i>
         '/<em[^>]*>(.*?)<\/em>/i',                        // <em>
         '/(<ul[^>]*>|<\/ul>)/i',                          // <ul> and </ul>
         '/(<ol[^>]*>|<\/ol>)/i',                          // <ol> and </ol>

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -26,6 +26,10 @@ class ImageTest extends \PHPUnit_Framework_TestCase
                 'html' => 'xx<img src="http://example.com/example.jpg" alt="An example image">xx',
                 'expected'  => 'xx[An example image]xx',
             ),
+            'With italics' => array(
+                'html' => '<img src="shrek.jpg" alt="the ogrelord" /> Blah <i>blah</i> blah',
+                'expected' => '[the ogrelord] Blah _blah_ blah'
+            )
         );
     }
 


### PR DESCRIPTION
The regex for `<i>` tags is currently not restrictive enough. When an `<i>` tag is before an `<img`> tag in the same line, it will match from `<img>` to `</i>`.