### PR TITLE
More restrictive regex for tags

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -49,25 +49,25 @@ class Html2Text
     protected $search = array(
         "/\r/",                                           // Non-legal carriage return
         "/[\n\t]+/",                                      // Newlines and tabs
-        '/<head[^>]*>.*?<\/head>/i',                      // <head>
-        '/<script[^>]*>.*?<\/script>/i',                  // <script>s -- which strip_tags supposedly has problems with
-        '/<style[^>]*>.*?<\/style>/i',                    // <style>s -- which strip_tags supposedly has problems with
-        '/<i[^>]*>(.*?)<\/i>/i',                          // <i>
-        '/<em[^>]*>(.*?)<\/em>/i',                        // <em>
-        '/(<ul[^>]*>|<\/ul>)/i',                          // <ul> and </ul>
-        '/(<ol[^>]*>|<\/ol>)/i',                          // <ol> and </ol>
-        '/(<dl[^>]*>|<\/dl>)/i',                          // <dl> and </dl>
-        '/<li[^>]*>(.*?)<\/li>/i',                        // <li> and </li>
-        '/<dd[^>]*>(.*?)<\/dd>/i',                        // <dd> and </dd>
-        '/<dt[^>]*>(.*?)<\/dt>/i',                        // <dt> and </dt>
-        '/<li[^>]*>/i',                                   // <li>
-        '/<hr[^>]*>/i',                                   // <hr>
-        '/<div[^>]*>/i',                                  // <div>
-        '/(<table[^>]*>|<\/table>)/i',                    // <table> and </table>
-        '/(<tr[^>]*>|<\/tr>)/i',                          // <tr> and </tr>
-        '/<td[^>]*>(.*?)<\/td>/i',                        // <td> and </td>
+        '/<head\b[^>]*>.*?<\/head>/i',                    // <head>
+        '/<script\b[^>]*>.*?<\/script>/i',                // <script>s -- which strip_tags supposedly has problems with
+        '/<style\b[^>]*>.*?<\/style>/i',                  // <style>s -- which strip_tags supposedly has problems with
+        '/<i\b[^>]*>(.*?)<\/i>/i',                        // <i>
+        '/<em\b[^>]*>(.*?)<\/em>/i',                      // <em>
+        '/(<ul\b[^>]*>|<\/ul>)/i',                        // <ul> and </ul>
+        '/(<ol\b[^>]*>|<\/ol>)/i',                        // <ol> and </ol>
+        '/(<dl\b[^>]*>|<\/dl>)/i',                        // <dl> and </dl>
+        '/<li\b[^>]*>(.*?)<\/li>/i',                      // <li> and </li>
+        '/<dd\b[^>]*>(.*?)<\/dd>/i',                      // <dd> and </dd>
+        '/<dt\b[^>]*>(.*?)<\/dt>/i',                      // <dt> and </dt>
+        '/<li\b[^>]*>/i',                                 // <li>
+        '/<hr\b[^>]*>/i',                                 // <hr>
+        '/<div\b[^>]*>/i',                                // <div>
+        '/(<table\b[^>]*>|<\/table>)/i',                  // <table> and </table>
+        '/(<tr\b[^>]*>|<\/tr>)/i',                        // <tr> and </tr>
+        '/<td\b[^>]*>(.*?)<\/td>/i',                      // <td> and </td>
         '/<span class="_html2text_ignore">.+?<\/span>/i', // <span class="_html2text_ignore">...</span>
-        '/<(img)[^>]*alt=\"([^>"]+)\"[^>]*>/i',           // <img> with alt tag
+        '/<(img)\b[^>]*alt=\"([^>"]+)\"[^>]*>/i',         // <img> with alt tag
     );
 
     /**

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -26,6 +26,10 @@ class ImageTest extends \PHPUnit_Framework_TestCase
                 'html' => 'xx<img src="http://example.com/example.jpg" alt="An example image">xx',
                 'expected'  => 'xx[An example image]xx',
             ),
+            'With italics' => array(
+                'html' => '<img src="shrek.jpg" alt="the ogrelord" /> Blah <i>blah</i> blah',
+                'expected' => '[the ogrelord] Blah _blah_ blah'
+            )
         );
     }
 


### PR DESCRIPTION
The regex for <i> tags is currently not restrictive enough. When an <i> tag is before an <img> tag in the same line, it will match from <img> to </i>.
