### PR TITLE
Fix whitespace problem with pre tags containing brs

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -436,7 +436,8 @@ class Html2Text
     {
         // get the content of PRE element
         while (preg_match('/<pre[^>]*>(.*)<\/pre>/ismU', $text, $matches)) {
-            $this->preContent = $matches[1];
+            // Replace br tags with newlines to prevent the search-and-replace callback from killing whitespace
+            $this->preContent = preg_replace('/(<br\b[^>]*>)/i', "\n", $matches[1]);
 
             // Run our defined tags search-and-replace with callback
             $this->preContent = preg_replace_callback(

--- a/test/PreTest.php
+++ b/test/PreTest.php
@@ -4,9 +4,11 @@ namespace Html2Text;
 
 class PreTest extends \PHPUnit_Framework_TestCase
 {
-    public function testPre()
+    public function preDataProvider()
     {
-        $html =<<<'EOT'
+        return array(
+            'Basic pre' => array(
+                'html' => <<<EOT
 <p>Before</p>
 <pre>
 
@@ -17,9 +19,9 @@ HTML symbols &amp;
 
 </pre>
 <p>After</p>
-EOT;
-
-        $expected =<<<'EOT'
+EOT
+                ,
+                'expected' => <<<EOT
 Before
 
 Foo bar baz
@@ -28,8 +30,36 @@ HTML symbols &
 
 After
 
-EOT;
+EOT
+                ,
+            ),
+            'br in pre' => array(
+                'html' => <<<EOT
+<pre>
+some<br />  indented<br />  text<br />    on<br />    several<br />  lines<br />
+</pre>
+EOT
+                ,
+                'expected' => <<<EOT
+some
+  indented
+  text
+    on
+    several
+  lines
 
+
+EOT
+                ,
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider preDataProvider
+     */
+    public function testPre($html, $expected)
+    {
         $html2text = new Html2Text($html);
         $this->assertEquals($expected, $html2text->getText());
     }


### PR DESCRIPTION
Consider this HTML:

```html
<pre>
    <span>
void FillMeUp(char* in_string) {<br />  int i = 0;<br />  while (in_string[i] != \'\0\') {<br />    in_string[i] = \'X\';<br />    i++;<br />  }<br />}
    </span>
</pre>
```

In version 3 it was rendered like this:

```
void FillMeUp(char* in_string) {
  int i = 0;
  while (in_string[i] != \'\') {
    in_string[i] = \'X\';
    i++;
  }
}
```

But now in version 4 we get this:

```
void FillMeUp(char* in_string) {
int i = 0;
while (in_string[i] != \'\') {
in_string[i] = \'X\';
i++;
}
}
```

As best I can tell this has something to do with the changes to the `callbackSearch` array - specifically the <br> addition. 