### PR TITLE
Option to disable newline(s) being prepended before paragraphs or headings

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -208,15 +208,16 @@ class Html2Text
      * @type array
      */
     protected $options = array(
-        'do_links' => 'inline', // 'none'
-                                // 'inline' (show links inline)
-                                // 'nextline' (show links on the next line)
-                                // 'table' (if a table of link URLs should be listed after the text.
-                                // 'bbcode' (show links as bbcode)
-
-        'width' => 70,          //  Maximum width of the formatted text, in columns.
-                                //  Set this value to 0 (or less) to ignore word wrapping
-                                //  and not constrain text to a fixed-width column.
+        'do_links' => 'inline',             // 'none'
+                                            // 'inline' (show links inline)
+                                            // 'nextline' (show links on the next line)
+                                            // 'table' (if a table of link URLs should be listed after the text.
+                                            // 'bbcode' (show links as bbcod
+        'width' => 70,                      //  Maximum width of the formatted text, in columns.
+                                            //  Set this value to 0 (or less) to ignore word wrapping
+                                            //  and not constrain text to a fixed-width column.
+        'disable_newlines_prepend' => false //  When set to true there won't be any new lines prepended
+                                            //  in front of paragraphs or headings
     );
 
     private function legacyConstruct($html = '', $fromFile = false, array $options = array())
@@ -539,7 +540,11 @@ class Html2Text
                 $para = trim($para);
 
                 // Add trailing newlines for this para.
-                return "\n" . $para . "\n";
+                if ($this->options['disable_newlines_prepend']) {
+                    return $para . "\n";
+                } else {
+                    return "\n" . $para . "\n";
+                }
             case 'br':
                 return "\n";
             case 'b':
@@ -548,7 +553,11 @@ class Html2Text
             case 'th':
                 return $this->toupper("\t\t" . $matches[3] . "\n");
             case 'h':
-                return $this->toupper("\n\n" . $matches[3] . "\n\n");
+                if ($this->options['disable_newlines_prepend']) {
+                    return $this->toupper($matches[3] . "\n\n");
+                } else {
+                    return $this->toupper("\n\n" . $matches[3] . "\n\n");
+                }
             case 'a':
                 // override the link method
                 $linkOverride = null;

--- a/test/DisableNewlineTest.php
+++ b/test/DisableNewlineTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Html2Text;
+
+class DisabledNewlineTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNewLines()
+    {
+    	$html =<<<EOT
+<p>Between this and</p>
+<p>this paragraph there should be only one newline</p>
+
+<h1>and this also goes for headings</h1>
+EOT;
+        $expected =<<<EOT
+Between this and
+this paragraph there should be only one newline
+AND THIS ALSO GOES FOR HEADINGS
+
+
+EOT;
+
+        $html2text = new Html2Text($html, ['disable_newlines_prepend' => true]);
+        $output = $html2text->getText();
+
+        $this->assertEquals($expected, $output);
+    }
+}


### PR DESCRIPTION
In my use case (parsing emails) I need the option to disable newline(s) from being prepended before paragraphs or headings. 

This html:
```
<p>Paragraph 1</p>
<p>Paragraph 2</p>
<p></p>
<p>Paragraph 3</p>
<p>Paragraph 4</p>
<p>Paragraph 5</p>
```
Would turn into something like this:
```
Paragraph 1
Paragraph 2

Paragraph 3
Paragraph 4
Paragraph 5

```
Or literally: `Paragraph 1\nParagraph 2\n\nParagraph 3\nParagraph 4\nParagraph 5\n`

This can be enabled by setting the `disable_newlines_prepend` option to true. A test has been added and the test suite passes.