### PR TITLE
Remove test-related stuff from production archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/test/ export-ignore
+/.* export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
When installing a release with composer, we get the test-related stuff also.

What about removing this stuff? See the result of this PR here:
https://github.com/mlocati/html2text/archive/remove-from-zip-useless-files-for-production.zip

People that still wants all the non-production-only files may still have these options:

- git-clone this repository
- composer require --prefer-source

That way, developers are happy, users are happy... in conclusion, this makes the whole World happier :wink: