### PR TITLE
Shorten output when link target and display match

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -434,10 +434,16 @@ class Html2Text
 
             return $display . ' [' . ($index + 1) . ']';
         } elseif ($linkMethod == 'nextline') {
+            if ($url === $display) {
+                return $display;
+            }
             return $display . "\n[" . $url . ']';
         } elseif ($linkMethod == 'bbcode') {
             return sprintf('[url=%s]%s[/url]', $url, $display);
         } else { // link_method defaults to inline
+            if ($url === $display) {
+                return $display;
+            }
             return $display . ' [' . $url . ']';
         }
     }

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -145,4 +145,18 @@ EOT;
 
         $this->assertEquals($expected, $html2text->getText());
     }
+
+    public function testDoLinksWhenTargetInText()
+    {
+        $html = '<a href="http://example.com">http://example.com</a>';
+        $expected = 'http://example.com';
+
+        $html2text = new Html2Text($html, array('do_links' => 'inline'));
+
+        $this->assertEquals($expected, $html2text->getText());
+
+        $html2text = new Html2Text($html, array('do_links' => 'nextline'));
+
+        $this->assertEquals($expected, $html2text->getText());
+    }
 }


### PR DESCRIPTION
Fixes #34.

When the target and the display of a link are the same, like so:
```html
<a href="http://example.com">http://example.com</a>
```
no information will be lost if it's converted to the following plain text:
```
http://example.com
```

This pull request does that for the `inline` and `nextline` methods. Unit-tests included.