### PR TITLE
Support php71, allow hhvm failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
 before_script:
   - composer install


### PR DESCRIPTION
Updated `.travis.yml`, since the build in #77 failed.