### PR TITLE
Ability to use round brackets as a separator

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -208,15 +208,18 @@ class Html2Text
      * @type array
      */
     protected $options = array(
-        'do_links' => 'inline', // 'none'
-                                // 'inline' (show links inline)
-                                // 'nextline' (show links on the next line)
-                                // 'table' (if a table of link URLs should be listed after the text.
-                                // 'bbcode' (show links as bbcode)
+        'do_links' => 'inline',      // 'none'
+                                     // 'inline' (show links inline)
+                                     // 'nextline' (show links on the next line)
+                                     // 'table' (if a table of link URLs should be listed after the text.
+                                     // 'bbcode' (show links as bbcode)
 
-        'width' => 70,          //  Maximum width of the formatted text, in columns.
-                                //  Set this value to 0 (or less) to ignore word wrapping
-                                //  and not constrain text to a fixed-width column.
+        'width' => 70,               //  Maximum width of the formatted text, in columns.
+                                     //  Set this value to 0 (or less) to ignore word wrapping
+                                     //  and not constrain text to a fixed-width column.
+
+        'link_notation' => 'square', // 'square' my link text [http://my-url]
+                                     // 'round'  my link text (http://my-url)
     );
 
     private function legacyConstruct($html = '', $fromFile = false, array $options = array())
@@ -437,15 +440,23 @@ class Html2Text
             if ($url === $display) {
                 return $display;
             }
-            return $display . "\n[" . $url . ']';
+            return $this->displayLink($display, $url, "\n");
         } elseif ($linkMethod == 'bbcode') {
             return sprintf('[url=%s]%s[/url]', $url, $display);
         } else { // link_method defaults to inline
             if ($url === $display) {
                 return $display;
             }
-            return $display . ' [' . $url . ']';
+            return $this->displayLink($display, $url);
         }
+    }
+
+    private function displayLink($display, $url, $separator = ' ')
+    {
+        if ($this->options['link_notation'] === 'round') {
+            return $display . $separator . '(' . $url . ')';
+        }
+        return $display . $separator . '[' . $url . ']';
     }
 
     protected function convertPre(&$text)

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -23,16 +23,37 @@ EOT;
         $this->assertEquals($expected, $output);
     }
 
-    public function testDoLinksInline()
+    /**
+     * @dataProvider doLinksInlineProvider
+     */
+    public function testDoLinksInline(array $options, $expected)
     {
-        $expected =<<<EOT
-Link text [http://example.com]
-EOT;
-
-        $html2text = new Html2Text(self::TEST_HTML, array('do_links' => 'inline'));
+        $options = array_merge(array('do_links' => 'inline'), $options);
+        $html2text = new Html2Text(self::TEST_HTML, $options);
         $output = $html2text->getText();
 
         $this->assertEquals($expected, $output);
+    }
+
+    public function doLinksInlineProvider()
+    {
+        $expected_square = <<<EOT
+Link text [http://example.com]
+EOT;
+        $expected_round = <<<EOT
+Link text (http://example.com)
+EOT;
+
+        return array(
+            // Not passing the option should default to square
+            array(array(), $expected_square),
+            // Passing junk should default to square
+            array(array('link_notation' => 'junk'), $expected_square),
+            // Passing as square should be... square
+            array(array('link_notation' => 'square'), $expected_square),
+            // Passing as round should be round
+            array(array('link_notation' => 'round'), $expected_round),
+        );
     }
 
     public function testDoLinksNone()
@@ -47,17 +68,40 @@ EOT;
         $this->assertEquals($output, $expected);
     }
 
-    public function testDoLinksNextline()
+    /**
+     * @dataProvider doLinksNextlineProvider
+     */
+    public function testDoLinksNextline(array $options, $expected)
     {
-        $expected =<<<EOT
-Link text
-[http://example.com]
-EOT;
+        $options = array_merge(array('do_links' => 'nextline'), $options);
 
-        $html2text = new Html2Text(self::TEST_HTML, array('do_links' => 'nextline'));
+        $html2text = new Html2Text(self::TEST_HTML, $options);
         $output = $html2text->getText();
 
         $this->assertEquals($expected, $output);
+    }
+
+    public function doLinksNextlineProvider()
+    {
+        $expected_square = <<<EOT
+Link text
+[http://example.com]
+EOT;
+        $expected_round = <<<EOT
+Link text
+(http://example.com)
+EOT;
+
+        return array(
+            // Not passing the option should default to square
+            array(array(), $expected_square),
+            // Passing junk should default to square
+            array(array('link_notation' => 'junk'), $expected_square),
+            // Passing as square should be... square
+            array(array('link_notation' => 'square'), $expected_square),
+            // Passing as round should be round
+            array(array('link_notation' => 'round'), $expected_round),
+        );
     }
 
     public function testDoLinksInHtml()


### PR DESCRIPTION
By default links are converted from
```html
<a href="http://example.com">my text</a>
```
to
```
my text [http://example.com]
```
For English that is perfectly [fine use](https://en.oxforddictionaries.com/punctuation/parentheses-and-brackets) of square brackets.

But, in my specific case I'm converting html with Dutch text. In which square brackets are less ideal.

This PR adds a feature: passing the option `['link_notation' => 'round']`, would convert the text to
```
my text (http://example.com)
```

Which fits my use case a lot better :smile:.

Behaviour without passing this flag: the same as before.

Feedback, improvements welcome ofc.