### PR TITLE
Changed TD tag conversion

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -95,7 +95,7 @@ class Html2Text
         "<div>\n",                       // <div>
         "\n\n",                          // <table> and </table>
         "\n",                            // <tr> and </tr>
-        "\t\t\\1\n",                     // <td> and </td>
+        "\t\t\\1",                     // <td> and </td>
         "",                              // <span class="_html2text_ignore">...</span>
         '[\\2]',                         // <img> with alt tag
     );


### PR DESCRIPTION
The TD tag doesn't have to have an \n at the end. This way columns are not next to each other, but under each other. Wothout the last \n, the TD in the TR are displayed horizontally.