### PR TITLE
Rename StrToUpperTest class to HeaderTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1

--- a/test/HeaderTest.php
+++ b/test/HeaderTest.php
@@ -2,7 +2,7 @@
 
 namespace Html2Text;
 
-class StrToUpperTest extends \PHPUnit_Framework_TestCase
+class HeaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testToUpper()
     {


### PR DESCRIPTION
Hi,

Composer is complaining that html2text does not comply with PSR-4 autoloading standards.

```
Deprecation Notice: Class Html2Text\StrToUpperTest located in ./vendor/html2text/html2text/test/HeaderTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```

Indeed, HeaderTest.php contains a class named StrToUpperTest.

This PR fixes this issue by renaming the class to match the filename.