### PR TITLE
Reduced classmap pollution caused by loading tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,14 @@
     "type": "library",
     "license": "GPL-2.0-or-later",
     "autoload": {
-        "psr-4": { "Html2Text\\": ["src/", "test/"] }
+        "psr-4": {
+            "Html2Text\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Html2Text\\": "test/"
+        }
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Reduces classmap pollution when using an optimized or authoritative classmap by 94% (from 17 classes to 1)

Closes #100