### PR TITLE
Link list should also have html entities decoded. 

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -358,7 +358,7 @@ class Html2Text
         if ($this->linkList) {
             $text .= "\n\nLinks:\n------\n";
             foreach ($this->linkList as $i => $url) {
-                $text .= '[' . ($i + 1) . '] ' . $url . "\n";
+                $text .= '[' . ($i + 1) . '] ' . html_entity_decode($url, $this->htmlFuncFlags, self::ENCODING) . "\n";
             }
         }
 


### PR DESCRIPTION
The `html_entity_decode` is executed after links have been extracted but before the link list is built so html entities will still be present in the links. 

This PR fixes that issue, for known entities. 