### PR TITLE
Add do_images option to make it possible to omit image handling 

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -68,7 +68,7 @@ class Html2Text
         '/(<tr\b[^>]*>|<\/tr>)/i',                        // <tr> and </tr>
         '/<td\b[^>]*>(.*?)<\/td>/i',                      // <td> and </td>
         '/<span class="_html2text_ignore">.+?<\/span>/i', // <span class="_html2text_ignore">...</span>
-        '/<(img)\b[^>]*alt=\"([^>"]+)\"[^>]*>/i',         // <img> with alt tag
+        //'/<(img)\b[^>]*alt=\"([^>"]+)\"[^>]*>/i',       // <img> with alt tag
     );
 
     /**
@@ -99,7 +99,7 @@ class Html2Text
         "\n",                            // <tr> and </tr>
         "\t\t\\1\n",                     // <td> and </td>
         "",                              // <span class="_html2text_ignore">...</span>
-        '[\\2]',                         // <img> with alt tag
+        //'[\\2]',                       // <img> with alt tag
     );
 
     /**
@@ -145,7 +145,8 @@ class Html2Text
         '/<(strong)( [^>]*)?>(.*?)<\/strong>/i',                 // <strong>
         '/<(del)( [^>]*)?>(.*?)<\/del>/i',                       // <del>
         '/<(th)( [^>]*)?>(.*?)<\/th>/i',                         // <th> and </th>
-        '/<(a) [^>]*href=("|\')([^"\']+)\2([^>]*)>(.*?)<\/a>/i'  // <a href="">
+        '/<(a) [^>]*href=("|\')([^"\']+)\2([^>]*)>(.*?)<\/a>/i', // <a href="">
+        '/<(img)\b[^>]*alt=\"([^>"]+)\"[^>]*>/i',                // <img> with alt tag
     );
 
     /**
@@ -218,6 +219,7 @@ class Html2Text
                                 // 'nextline' (show links on the next line)
                                 // 'table' (if a table of link URLs should be listed after the text.
                                 // 'bbcode' (show links as bbcode)
+        'do_images' => true,
 
         'width' => 70,          //  Maximum width of the formatted text, in columns.
                                 //  Set this value to 0 (or less) to ignore word wrapping
@@ -587,6 +589,13 @@ class Html2Text
                 $url = str_replace(' ', '', $matches[3]);
 
                 return $this->buildlinkList($url, $matches[5], $linkOverride);
+            case 'img':
+                // Only attempt to handle images if option is true.
+                if ($this->options['do_images']) {
+                    return sprintf('[%s]', $matches[2]);
+                }
+
+                return '';
         }
 
         return '';

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -219,7 +219,8 @@ class Html2Text
                                 // 'nextline' (show links on the next line)
                                 // 'table' (if a table of link URLs should be listed after the text.
                                 // 'bbcode' (show links as bbcode)
-        'do_images' => true,
+
+        'do_images' => true,    // If false, omits image handling; essentially stripping them.
 
         'width' => 70,          //  Maximum width of the formatted text, in columns.
                                 //  Set this value to 0 (or less) to ignore word wrapping

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -9,26 +9,32 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             'Without alt tag' => array(
                 'html' => '<img src="http://example.com/example.jpg">',
                 'expected'  => '',
+                'expectedNoImage' => '',
             ),
             'Without alt tag, wrapped in text' => array(
                 'html' => 'xx<img src="http://example.com/example.jpg">xx',
                 'expected'  => 'xxxx',
+                'expectedNoImage' => 'xxxx',
             ),
             'With alt tag' => array(
                 'html' => '<img src="http://example.com/example.jpg" alt="An example image">',
                 'expected'  => '[An example image]',
+                'expectedNoImage' => '',
             ),
             'With alt, and title tags' => array(
                 'html' => '<img src="http://example.com/example.jpg" alt="An example image" title="Should be ignored">',
                 'expected'  => '[An example image]',
+                'expectedNoImage' => '',
             ),
             'With alt tag, wrapped in text' => array(
                 'html' => 'xx<img src="http://example.com/example.jpg" alt="An example image">xx',
                 'expected'  => 'xx[An example image]xx',
+                'expectedNoImage' => 'xxxx',
             ),
             'With italics' => array(
                 'html' => '<img src="shrek.jpg" alt="the ogrelord" /> Blah <i>blah</i> blah',
-                'expected' => '[the ogrelord] Blah _blah_ blah'
+                'expected' => '[the ogrelord] Blah _blah_ blah',
+                'expectedNoImage' => ' Blah _blah_ blah',
             )
         );
     }
@@ -36,11 +42,17 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testImageDataProvider
      */
-    public function testImages($html, $expected)
+    public function testImages($html, $expected, $expectedNoImage)
     {
         $html2text = new Html2Text($html);
         $output = $html2text->getText();
 
         $this->assertEquals($expected, $output);
+
+        // Test with ['do_images' => false]
+        $html2text = new Html2Text($html, ['do_images' => false]);
+        $output = $html2text->getText();
+
+        $this->assertEquals($expectedNoImage, $output);
     }
 }


### PR DESCRIPTION
Thanks for this great library.  I have a case where it's not desirable to replace images with their `alt` values, so that's what this solves.

Tried to stick with existing convention as `do_links`.