### PR TITLE
Add missing encoding

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -417,7 +417,7 @@ class Html2Text
         }
 
         // Ignored link types
-        if (preg_match('!^(javascript:|mailto:|#)!i', html_entity_decode($link))) {
+        if (preg_match('!^(javascript:|mailto:|#)!i', html_entity_decode($link, $this->htmlFuncFlags, self::ENCODING))) {
             return $display;
         }
 


### PR DESCRIPTION
Add missing encoding to avoid following Error:

ERROR: html_entity_decode(): charset `UTF8' not supported, assuming utf-8 on line 420 in file ..../vendor\/html2text\/html2text\/src\/Html2Text.php.
