### PR TITLE
Fix `html_entity_decode` deprecation warning in PHP 8.1

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -236,6 +236,10 @@ class Html2Text
      */
     public function __construct($html = '', $options = array())
     {
+        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
+            ? ENT_QUOTES
+            : ENT_QUOTES | ENT_HTML5;
+
         // for backwards compatibility
         if (!is_array($options)) {
             return call_user_func_array(array($this, 'legacyConstruct'), func_get_args());
@@ -243,9 +247,6 @@ class Html2Text
 
         $this->html = $html;
         $this->options = array_merge($this->options, $options);
-        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
-            ? ENT_QUOTES
-            : ENT_QUOTES | ENT_HTML5;
     }
 
     /**


### PR DESCRIPTION
Passing null as the second parameter is deprecated in PHP 8.1. When using the
`legacyConstruct` function the `htmlFuncFlags` are never set and passing null
into `html_entity_decode`.

This move setting `htmlFuncFlags` above the legacy check to ensure they are
always set to prevent passing null into `html_entity_decode`.