### PR TITLE
Exclude files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+test/            export-ignore
+.gitignore       export-ignore
+.travis.yml      export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-test/            export-ignore
-.gitattributes   export-ignore
-.gitignore       export-ignore
-.travis.yml      export-ignore
-phpunit.xml.dist export-ignore
+/test/            export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 test/            export-ignore
+.gitattributes   export-ignore
 .gitignore       export-ignore
 .travis.yml      export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
For the time being, when fetching the dist package from composer, all repository files are included.
Using `export-ignore` git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).

Ignore files weight: 21.2kB
Remaining files weight: 23.0kB