### PR TITLE
Clean up PHP 8.2 compatibility, duplicated test run

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -352,7 +352,7 @@ class Html2Text
     {
         $this->linkList = array();
 
-        $text = trim($this->html);
+        $text = trim($this->html ?? '');
 
         $this->converter($text);
 
@@ -390,7 +390,7 @@ class Html2Text
         $text = preg_replace("/[\n]{3,}/", "\n\n", $text);
 
         // remove leading empty lines (can be produced by eg. P tag on the beginning)
-        $text = ltrim($text, "\n");
+        $text = ltrim($text ?? '', "\n");
 
         if ($this->options['width'] > 0) {
             $text = wordwrap($text, $this->options['width']);

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -236,6 +236,10 @@ class Html2Text
      */
     public function __construct($html = '', $options = array())
     {
+        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
+            ? ENT_QUOTES
+            : ENT_QUOTES | ENT_HTML5;
+
         // for backwards compatibility
         if (!is_array($options)) {
             return call_user_func_array(array($this, 'legacyConstruct'), func_get_args());
@@ -243,9 +247,6 @@ class Html2Text
 
         $this->html = $html;
         $this->options = array_merge($this->options, $options);
-        $this->htmlFuncFlags = (PHP_VERSION_ID < 50400)
-            ? ENT_QUOTES
-            : ENT_QUOTES | ENT_HTML5;
     }
 
     /**

--- a/test/ImageTest.php
+++ b/test/ImageTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class ImageTest extends TestCase
 {
-    public function testImageDataProvider() {
+    public function imageDataProvider() {
         return array(
             'Without alt tag' => array(
                 'html' => '<img src="http://example.com/example.jpg">',
@@ -36,7 +36,7 @@ class ImageTest extends TestCase
     }
 
     /**
-     * @dataProvider testImageDataProvider
+     * @dataProvider imageDataProvider
      */
     public function testImages($html, $expected)
     {

--- a/test/PrintTest.php
+++ b/test/PrintTest.php
@@ -11,15 +11,15 @@ class PrintTest extends TestCase
 
     public function testP()
     {
-        $this->html = new Html2Text(self::TEST_HTML);
-        $this->html->p();
+        $html = new Html2Text(self::TEST_HTML);
+        $html->p();
         $this->expectOutputString(self::EXPECTED);
     }
 
     public function testPrint_text()
     {
-        $this->html = new Html2Text(self::TEST_HTML);
-        $this->html->print_text();
+        $html = new Html2Text(self::TEST_HTML);
+        $html->print_text();
         $this->expectOutputString(self::EXPECTED);
     }
 }


### PR DESCRIPTION
See #113 and #117, though for the latter this fixes reversions that affect #117. Combined with tweaks to the tests, this gets us a clean run (no deprecation errors) on PHP 8.2.