### PR TITLE
Remove syntaxCheck phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="test/bootstrap.php"
 >
     <testsuites>


### PR DESCRIPTION
This was deprecated and removed by PHPUnit around 10-12 years ago.