### PR TITLE
Update constructor usage of call_user_func_array

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -242,7 +242,9 @@ class Html2Text
 
         // for backwards compatibility
         if (!is_array($options)) {
-            return call_user_func_array(array($this, 'legacyConstruct'), func_get_args());
+            // phpcs:ignore (PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+            call_user_func_array(array($this, 'legacyConstruct'), func_get_args());
+            return;
         }
 
         $this->html = $html;


### PR DESCRIPTION
Ignore phpcompat errors as they do not impact us in this case Also do not return the alue of the `call_user_func_array`, but return a void value.

Fixes #104